### PR TITLE
Update dependencies for NestJS 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "qs": "^6.11.0"
       },
       "devDependencies": {
-        "@nestjs/common": "^9.2.0 || ^10.0.0",
-        "@nestjs/core": "^9.2.0 || ^10.0.0",
+        "@nestjs/common": "^9.2.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.2.0 || ^10.0.0 || ^11.0.0",
         "@types/express": "^4.17.14",
         "@types/node": "^18.11.9",
         "@types/qs": "^6.9.7",
@@ -28,8 +28,8 @@
         "typescript": "^4.9.3"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.2.0 || ^10.0.0",
-        "@nestjs/core": "^9.2.0 || ^10.0.0",
+        "@nestjs/common": "^9.2.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.2.0 || ^10.0.0 || ^11.0.0",
         "reflect-metadata": "^0.1.13"
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/tumainimosha/nestjs-url-generator#readme",
   "devDependencies": {
-    "@nestjs/common": "^9.2.0 || ^10.0.0",
-    "@nestjs/core": "^9.2.0 || ^10.0.0",
+    "@nestjs/common": "^9.2.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.2.0 || ^10.0.0 || ^11.0.0",
     "@types/express": "^4.17.14",
     "@types/node": "^18.11.9",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
@@ -50,8 +50,8 @@
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.2.0 || ^10.0.0",
-    "@nestjs/core": "^9.2.0 || ^10.0.0",
+    "@nestjs/common": "^9.2.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^9.2.0 || ^10.0.0 || ^11.0.0",
     "reflect-metadata": "^0.1.13"
   },
   "dependencies": {

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -1884,8 +1884,8 @@
         "qs": "^6.11.0"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.2.0 || ^10.0.0",
-        "@nestjs/core": "^9.2.0 || ^10.0.0",
+        "@nestjs/common": "^9.2.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.2.0 || ^10.0.0 || ^11.0.0",
         "reflect-metadata": "^0.1.13"
       }
     },
@@ -6781,8 +6781,8 @@
         "qs": "^6.11.0"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.2.0 || ^10.0.0",
-        "@nestjs/core": "^9.2.0 || ^10.0.0",
+        "@nestjs/common": "^9.2.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.2.0 || ^10.0.0 || ^11.0.0",
         "reflect-metadata": "^0.1.13"
       }
     },


### PR DESCRIPTION
## Summary
- support NestJS v11 in peer/dev dependencies
- document general Nest compatibility

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_684099f181ac832799a433632a206dd6